### PR TITLE
Use custom lense for master.cf to support unix-dgram type

### DIFF
--- a/files/augeas/postfix_master.aug
+++ b/files/augeas/postfix_master.aug
@@ -1,0 +1,57 @@
+(* Postfix_Master module for Augeas
+ Author: Free Ekanayaka <free@64studio.com>
+ Reference:
+
+*)
+
+module Postfix_Master =
+
+   autoload xfm
+
+(************************************************************************
+ *                           USEFUL PRIMITIVES
+ *************************************************************************)
+
+let eol        = Util.eol
+let ws         = del /[ \t\n]+/ " "
+let comment    = Util.comment
+let empty      = Util.empty
+
+let word       = /[A-Za-z0-9_.:-]+/
+let words      =
+     let char_start = /[A-Za-z0-9$!(){}=_.,:@-]/
+  in let char_end = char_start | /[]["\/]/
+  in let char_middle = char_end | " "
+  in char_start . char_middle* . char_end
+
+let bool       = /y|n|-/
+let integer    = /([0-9]+|-)\??/
+let command   = words . (/[ \t]*\n[ \t]+/ . words)*
+
+let field (l:string) (r:regexp)
+               = [ label l . store r ]
+
+(************************************************************************
+ *                               ENTRIES
+ *************************************************************************)
+
+let entry     = [ key word . ws
+                . field "type"         /inet|unix(-dgram)?|fifo|pass/  . ws
+                . field "private"      bool                   . ws
+                . field "unprivileged" bool                   . ws
+                . field "chroot"       bool                   . ws
+                . field "wakeup"       integer                . ws
+                . field "limit"        integer                . ws
+                . field "command"      command
+                . eol ]
+
+(************************************************************************
+ *                                LENS
+ *************************************************************************)
+
+let lns        = (comment|empty|entry) *
+
+let filter     = incl "/etc/postfix/master.cf"
+               . incl "/usr/local/etc/postfix/master.cf"
+
+let xfm        = transform lns filter

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,24 @@ class postfix(
     require => Package['postfix'],
   }
 
+  # The custom version of augeas lense for master.cf.
+  # The stock version does not (yet) support the unix-dgram service type.
+  # This causes issues with the default master.cf on buster.
+  # Hence this fix until upstream gets updated.
+  file { '/etc/postfix/augeas':
+    ensure  => 'directory',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0755',
+  }
+  file { '/etc/postfix/augeas/postfix_master.aug':
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => file('postfix/augeas/postfix_master.aug'),
+    require => File['/etc/postfix/augeas']
+  }
+
   file { '/etc/postfix/transport':
     ensure  => 'present',
     content => '# managed by puppet',

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -9,6 +9,7 @@ define postfix::service(
   $wakeup = '-',
   $limit = 100,
 ) {
+  $load_path = '/etc/postfix/augeas'
   $use_service = $service ? {
     ''      => $name,
     default => $service,
@@ -23,15 +24,16 @@ define postfix::service(
 
   if ($ensure == 'absent') {
     augeas { "remove postfix master ${name}":
-      context => '/files/etc/postfix/master.cf',
-      changes => "rm ${existing_name}",
-      notify  => Service['postfix'],
-      require => File['/etc/postfix/master.cf'],
+      context   => '/files/etc/postfix/master.cf',
+      changes   => "rm ${existing_name}",
+      notify    => Service['postfix'],
+      require   => File['/etc/postfix/master.cf'],
+      load_path => $load_path,
     }
   } else {
     augeas { "manage postfix master ${name}":
-      context => '/files/etc/postfix/master.cf',
-      changes => [
+      context   => '/files/etc/postfix/master.cf',
+      changes   => [
         "set ${existing_name}/type ${type}",
         "set ${existing_name}/private ${private_bool}",
         "set ${existing_name}/unprivileged ${unprivileged_bool}",
@@ -40,14 +42,15 @@ define postfix::service(
         "set ${existing_name}/limit ${limit}",
         "set ${existing_name}/command ${command}",
       ],
-      notify  => Service['postfix'],
-      require => File['/etc/postfix/master.cf'],
-      onlyif  => "match ${existing_name} size == 1",
+      notify    => Service['postfix'],
+      require   => File['/etc/postfix/master.cf'],
+      onlyif    => "match ${existing_name} size == 1",
+      load_path => $load_path,
     }
 
     augeas { "add postfix master ${name}":
-      context => '/files/etc/postfix/master.cf',
-      changes => [
+      context   => '/files/etc/postfix/master.cf',
+      changes   => [
         "set ${use_service}[last()+1]/type ${type}",
         "set ${new_name}/private ${private_bool}",
         "set ${new_name}/unprivileged ${unprivileged_bool}",
@@ -56,9 +59,10 @@ define postfix::service(
         "set ${new_name}/limit ${limit}",
         "set ${new_name}/command ${command}",
       ],
-      notify  => Service['postfix'],
-      require => File['/etc/postfix/master.cf'],
-      onlyif  => "match ${existing_name} size == 0",
+      notify    => Service['postfix'],
+      require   => File['/etc/postfix/master.cf'],
+      onlyif    => "match ${existing_name} size == 0",
+      load_path => $load_path,
     }
   }
 }


### PR DESCRIPTION
Postfix version 3.4 adds unix-dgram type to master.cf. The master.cf that comes default on buster has this line:
```
postlog   unix-dgram n  -       n       -       1       postlogd
```
The line is ineffective until enabled in main.cf (references: [1](http://www.postfix.org/MAILLOG_README.html), [2](http://www.postfix.org/postlogd.8.html)). But, the stock lense does not support this type (yet), which is causing parse error while managing services in master.cf.   Hence adding the custom lense for master.cf as a work around. 

Only change to stock lense is RE on line 39 changes from ` /inet|unix|fifo|pass/` to ` /inet|unix(-dgram)?|fifo|pass/`

Relevant puppet run excerpts as proof of life:
```
Notice: /Stage[main]/Postfix/File[/etc/postfix/augeas]/ensure: created
Notice: /Stage[main]/Postfix/File[/etc/postfix/augeas/postfix_master.aug]/ensure: defined content as '{md5}e9ce800c5c54a342347e7f04cedd1b76'
```
```
Notice: Augeas[add postfix master policyd-spf](provider=augeas):
--- /etc/postfix/master.cf	2020-07-13 14:58:02.566820169 +0000
+++ /etc/postfix/master.cf.augnew	2020-07-13 14:58:43.462344744 +0000
@@ -124,3 +124,4 @@
 mailman   unix  -       n       n       -       -       pipe
   flags=FR user=list argv=/usr/lib/mailman/bin/postfix-to-mailman.py
   ${nexthop} ${user}
+policyd-spf unix - n - - 100 spawn user=policyd-spf argv=/usr/bin/policyd-spf

Notice: /Stage[main]/Bigcommerce_mail_forwarder::Policyd_spf/Postfix::Service[policyd-spf]/Augeas[add postfix master policyd-spf]/returns: executed successfully
```